### PR TITLE
Updating subscriptions for OCP4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ helm uninstall sno-srv-install --namespace factory
 helm uninstall sno-install --namespace factory
 helm uninstall sno-core-install --namespace factory
 helm uninstall sno-olm-install --namespace factory
-helm delete secret factory-data --namespace factory
-helm delete secret factory-secret --namespace factory
-helm delete secret endpoint-service-edge-secret --namespace factory
-helm delete secret endpoint-service-tls-secret --namespace factory
+oc delete secret factory-data --namespace factory
+oc delete secret factory-secret --namespace factory
+oc delete secret endpoint-service-edge-secret --namespace factory
+oc delete secret endpoint-service-tls-secret --namespace factory
 oc delete subscription amq-broker -n factory
 oc delete subscription cert-manager -n openshift-operators
 oc delete subscription openshift-gitops-operator -n openshift-operators

--- a/sno-olm-install/templates/amq-broker/amq-broker-subscription.yaml
+++ b/sno-olm-install/templates/amq-broker/amq-broker-subscription.yaml
@@ -1,11 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: amq-broker
+  name: amq-broker-rhel8
 spec:
-  channel: current
+  channel: 7.10.x
   installPlanApproval: Automatic
-  name: amq-broker
+  name: amq-broker-rhel8
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   startingCSV: {{ .Values.amqbroker.startingCSV }}

--- a/sno-olm-install/templates/gitops/gitops-subscription.yaml
+++ b/sno-olm-install/templates/gitops/gitops-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-operators
 spec:
-  channel: stable
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/sno-olm-install/values.yaml
+++ b/sno-olm-install/values.yaml
@@ -4,12 +4,12 @@ kafkaclient:
   
 ########## A-MQ Broker ##########
 amqbroker:
-  startingCSV: amq-broker-operator.v7.8.3-opr-1
+  startingCSV: amq-broker-operator.v7.10.0-opr-3
   
 ########## GitOps ##########
 gitops:
-  startingCSV: openshift-gitops-operator.v1.3.1
+  startingCSV: openshift-gitops-operator.v1.6.0
 
 ########## Cert Manager ##########
 certmanager:
-  startingCSV: cert-manager.v1.6.1
+  startingCSV: cert-manager.v1.9.1


### PR DESCRIPTION
Small update to the Readme where helm was referenced instead of `oc` and updated OLM subscriptions for OCP4.10.